### PR TITLE
[Feat]/30 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ['main', 'develop']
+    types: [opened, synchronize, reopened]
+  push:
+    branches: ['main', 'develop']
+
+# 같은 브랜치에서 이전 실행을 취소(시간 절약)
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_test:
+    runs-on: ubuntu-latest
+    # Node 20(LTS)와 22(현재 로컬) 둘 다 검증
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      # Vite용 환경변수 주입: 레포 Secrets에 저장된 값을 .env.ci로 생성
+      # - name: Create .env.ci
+      #   if: ${{ secrets.VITE_API_BASE_URL != '' }}
+      #   run: |
+      #     echo "VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}" >> .env.ci
+
+      # - name: Install deps
+      #   run: npm ci
+
+      # - name: Lint
+      #   run: npm run lint
+
+      # - name: Type Check
+      #   run: npm run typecheck
+
+      # 추후 테스트 추가 시! 없다면 이 단계 삭제
+      # - name: Unit Test
+      #   run: npm test
+
+      # - name: Build
+      #   env:
+      #     NODE_ENV: production
+      #   run: npm run build
+
+      # 아티팩트 업로드 — 실패해도 디버깅에 도움
+      - name: Upload build artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-node${{ matrix.node-version }}
+          path: dist
+          if-no-files-found: warn

--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -5,7 +5,9 @@ on:
     types: [opened, review_requested, closed]
   pull_request_review:
     types: [submitted]
-
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
 env:
   WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
@@ -35,6 +37,78 @@ jobs:
                   { name: "📊 변경사항", value: `+${pr.additions ?? 0} -${pr.deletions ?? 0}`, inline: true },
                 ],
                 timestamp: pr.created_at
+              }]
+            };
+
+            await fetch(webhook, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+
+      # PR 작업내용(커밋/변경파일) 요약 알림
+      - name: Notify Work Summary (on opened/synchronize/edited)
+        if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'edited')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const webhook = process.env.WEBHOOK;
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            // 커밋/파일 목록 조회
+            const commitsRes = await github.rest.pulls.listCommits({
+              owner, repo, pull_number: pr.number, per_page: 100
+            });
+            const filesRes = await github.rest.pulls.listFiles({
+              owner, repo, pull_number: pr.number, per_page: 300
+            });
+
+            // 커밋 요약 (상위 8개)
+            const commits = commitsRes.data || [];
+            const maxCommits = 8;
+            const commitLines = commits
+              .map(c => `- ${c.commit.message.split('\n')[0]} (${c.sha.slice(0,7)})`)
+              .slice(0, maxCommits)
+              .join('\n');
+            const extraCommits = commits.length > maxCommits ? `\n…외 ${commits.length - maxCommits}건` : '';
+
+            // 변경 파일 목록 (상위 10개)
+            const files = filesRes.data || [];
+            const maxFiles = 10;
+            const fileLines = files
+              .slice(0, maxFiles)
+              .map(f => `- ${f.filename}`)
+              .join('\n');
+            const extraFiles = files.length > maxFiles ? `\n…외 ${files.length - maxFiles}개 파일` : '';
+
+            // 1024자 제한 대비 잘라내기
+            const clamp = (s, n=1024) => s.length > n ? s.slice(0, n - 1) + '…' : s;
+
+            // 상세 링크
+            const compareUrl = `${pr.html_url}/files`; // 파일 변경 탭
+            const commitsUrl = `${pr.html_url}/commits`; // 커밋 탭
+
+            const payload = {
+              embeds: [{
+                title: "🛠 작업 내용 요약",
+                description: `[${pr.title}](${pr.html_url})`,
+                color: 5793266,
+                fields: [
+                  {
+                    name: "🧩 커밋 요약",
+                    value: clamp(commitLines + extraCommits || "커밋 정보가 없습니다.")
+                  },
+                  {
+                    name: "🗂 변경 파일",
+                    value: clamp(fileLines + extraFiles || "변경된 파일이 없습니다.")
+                  },
+                  {
+                    name: "🔗 자세히 보기",
+                    value: `[커밋 목록](${commitsUrl}) | [파일 변경](${compareUrl})`
+                  }
+                ],
+                timestamp: new Date().toISOString()
               }]
             };
 
@@ -208,6 +282,85 @@ jobs:
                   { name: "👀 리뷰어", value: review.user?.login ?? "unknown", inline: true },
                   { name: "📝 요청사항", value: "변경사항이 요청되었습니다. 자세한 내용은 PR을 확인해주세요.", inline: false },
                 ],
+              }]
+            };
+
+            await fetch(webhook, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+
+  ci_summary:
+    # CI가 끝났을 때만 실행 (이 워크플로우는 workflow_run에서 호출됨)
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # run의 job 목록 조회
+      contents: read
+    steps:
+      - name: Post CI Summary to Discord
+        uses: actions/github-script@v7
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        with:
+          script: |
+            const webhook = process.env.WEBHOOK;
+            const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+
+            // CI 워크플로우 실행의 Jobs 조회
+            const jobsRes = await github.rest.actions.listJobsForWorkflowRun({
+              owner, repo, run_id: run.id, per_page: 100
+            });
+            const jobs = jobsRes.data.jobs || [];
+
+            // 매트릭스 Job만 추려내기 (이름에 build_test 또는 ci job 이름이 포함)
+            const targetJobs = jobs.filter(j => /build_test|build_only|test|build/i.test(j.name));
+
+            // 상태 이모지
+            const toEmoji = (c) => ({
+              success: "✅",
+              failure: "❌",
+              cancelled: "🚫",
+              timed_out: "⏰",
+              neutral: "⚪",
+              skipped: "⏭️",
+              action_required: "⚠️",
+              stale: "🕓"
+            }[String(c || '').toLowerCase()] || "❓");
+
+            // 시간/링크
+            const runUrl = run.html_url;
+            const branch = run.head_branch;
+            const statusEmoji = toEmoji(run.conclusion);
+            const title = `${statusEmoji} CI 완료 — ${owner}/${repo} @ ${branch}`;
+            const when = run.updated_at || run.created_at || new Date().toISOString();
+
+            // 각 Job 요약 (예: build_test / Node 20, build_test / Node 22)
+            const lines = targetJobs.map(j => {
+              const durMs = (new Date(j.completed_at) - new Date(j.started_at)) || 0;
+              const sec = Math.max(1, Math.round(durMs / 1000));
+              return `• ${toEmoji(j.conclusion)} ${j.name} (${sec}s)`;
+            });
+
+            // 관련 PR 링크(있으면)
+            const prs = run.pull_requests || [];
+            const prLink = prs[0]?.html_url ? `[PR #${prs[0].number}](${prs[0].html_url})` : "해당 없음";
+
+            // 디스코드 임베드
+            const payload = {
+              embeds: [{
+                title,
+                description: `[Workflow Run 열기](${runUrl})`,
+                color: String(run.conclusion).toLowerCase() === 'success' ? 65280 : 16711680, // 초록/빨강
+                fields: [
+                  { name: "대상 브랜치", value: `\`${branch}\``, inline: true },
+                  { name: "결과", value: String(run.conclusion || 'unknown'), inline: true },
+                  { name: "관련 PR", value: prLink, inline: false },
+                  { name: "매트릭스 결과", value: lines.length ? lines.join('\n') : "결과를 찾을 수 없습니다.", inline: false },
+                ],
+                timestamp: when
               }]
             };
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -p tsconfig.app.json && vite build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## 📌 개요

CI 기능 및 Discord Webhook 연동 개선 작업을 진행

## ✅ 변경 사항

- [x] GitHub Actions에 Node.js 20 + 22 매트릭스 CI 추가
- [x] Lint, Type Check, Unit Test, Build 단계 구성
- [x] Discord Webhook 알림에 PR 작업내용(커밋 요약, 변경 파일) 추가
- [x] CI 완료 시(성공/실패) 매트릭스 결과를 Discord로 전송하는 기능 추가

## 🔗 관련 이슈

#30

## 📷 참고 자료 (선택)

- GitHub Actions Workflow 파일: `.github/workflows/ci.yml`
- Discord Webhook 설정: `.github/workflows/discord.yml`

## 💬 기타

- CI 결과는 Node 20(LTS)와 Node 22(로컬 환경) 모두 검증됩니다.
- Discord 알림은 PR 생성/리뷰 요청/승인/변경 요청/닫힘/CI 완료 시점에 전송됩니다.

---

closes #30
