### PR TITLE
[fix] 실행 브랜치 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   pull_request:
-    branches: ['main', 'develop']
+    branches: ['main', 'dev']
     types: [opened, synchronize, reopened]
   push:
-    branches: ['main', 'develop']
+    branches: ['main', 'dev']
 
 # 같은 브랜치에서 이전 실행을 취소(시간 절약)
 concurrency:


### PR DESCRIPTION
## 📌 개요

CI 워크플로우에서 잘못 설정된 브랜치명을 수정했습니다.  
(`develop` → `dev` 로 변경)

## ✅ 변경 사항

- [x] GitHub Actions 워크플로우(`.github/workflows/ci.yml`) 브랜치 트리거 수정  
  - 기존: `branches: ['main', 'develop']`  
  - 변경: `branches: ['main', 'dev']`
- [x] 브랜치 보호 규칙과 CI 트리거 브랜치 일관성 확보

## 🔗 관련 이슈

#30

## 📷 참고 자료 (선택)

- GitHub Actions 설정 화면
- 브랜치 보호 규칙 스크린샷

## 💬 기타

- 앞으로는 `dev` 브랜치에서만 CI가 실행되도록 관리합니다.  
- `develop` 브랜치는 더 이상 사용하지 않으므로 혼동 주의 바랍니다.

---

closes #30