### PR TITLE
[Fix] 토스트 알림 발생 시 좌우 여백 클릭 안 됨 현상 해결

### DIFF
--- a/src/components/ui/Toast/Toast.styles.ts
+++ b/src/components/ui/Toast/Toast.styles.ts
@@ -4,7 +4,7 @@ import WarningIcon from '@assets/icons/toast_warning.svg'
 import ErrorIcon from '@assets/icons/toast_error.svg'
 
 export const TOAST_COMMON_STYLES =
-  'animate-fade-in-out-toast flex justify-start items-center gap-x-3 w-2/3 p-[17px] rounded-lg opacity-0 transition'
+  'pointer-events-auto animate-fade-in-out-toast flex justify-start items-center gap-x-3 w-2/3 p-[17px] rounded-lg opacity-0 transition'
 
 export const TOAST_STYLES = {
   info: {

--- a/src/components/ui/Toast/ToastContainer.tsx
+++ b/src/components/ui/Toast/ToastContainer.tsx
@@ -14,7 +14,7 @@ export function ToastContainer() {
   }, [debouncedToasts])
 
   return (
-    <div className="fixed inset-x-0 top-8 z-100 flex flex-col items-center gap-y-3">
+    <div className="pointer-events-none fixed inset-x-0 top-8 z-100 flex flex-col items-center gap-y-3">
       {renderedToasts.map(({ id, type, title, content }) => (
         <Toast key={id} id={id} type={type} title={title} content={content} />
       ))}


### PR DESCRIPTION
토스트 알림 발생 시 좌우 여백 클릭도 되지 않았던 원인은,
ToastContainer의 inset-x-0 때문에 컨테이너가 화면 가로 전체를 덮어서 투명한 영역도 클릭을 가로챘기 때문입니다.

이에
ToastContainer는 pointer-events-none,
Toast는 pointer-events-auto로 설정하여

컨테이너(빈 공간)는 클릭이 통과하고 토스트 카드는 클릭이 통과하지 못하게 했습니다.