### PR TITLE
fix: PR 시에 배포 코멘트가 누락

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -6,7 +6,13 @@ on:
       - dev # ← 배포 브랜치
       - 'feature/**' # ← preview 배포 브랜치
       - 'fix/**' # ← preview 배포 브랜치
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   deploy:
@@ -63,18 +69,33 @@ jobs:
           echo "✅ Deployed: $DEPLOY_URL"
 
       - name: Comment Preview URL on PR
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const url = process.env.DEPLOY_URL;
-            const pr = context.payload.pull_request;
-            if (pr) {
-              github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: `🚀 Vercel Preview 배포 완료!\n\n🔗 [배포 URL](${url})`
+            const { owner, repo } = context.repo;
+            const event = context.eventName;
+            const branch = context.ref.replace('refs/heads/', '');
+
+            // PR 이벤트면 바로 코멘트
+            if (event === 'pull_request') {
+              const prNum = context.payload.pull_request.number;
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNum,
+                body: `🚀 Vercel 배포 완료\n\n🔗 ${url}`
               });
+            } else {
+              // push 이벤트인 경우: 현재 브랜치로 열린 PR을 찾아 코멘트
+              const { data: prs } = await github.rest.pulls.list({
+                owner, repo, state: 'open', head: `${owner}:${branch}`
+              });
+              if (prs.length > 0) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: prs[0].number,
+                  body: `🚀 Vercel 배포 완료\n\n🔗 ${url}`
+                });
+              } else {
+                core.info(`No open PR for ${branch}; skipping comment.`);
+              }
             }


### PR DESCRIPTION
- 워크플로우 트리거에 pull_request 추가
- 허가에 pull-requests: write 명시
- push 이벤트에서도 열린 PR 찾아 코멘트 남기도록 스크립트 수정

## 📌 개요

Vercel 배포 관련 GitHub Actions 워크플로우(`.yml`) 설정을 수정
배포 시 발생하던 오류를 해결하고, CI/CD 파이프라인이 안정적으로 동작하도록 개선

## ✅ 변경 사항

- [x] GitHub Actions 워크플로우 내 Vercel 설정 수정
- [x] `fetch-depth` 및 의존성 관련 설정 최적화
- [x] PR 생성 시 자동 배포가 정상적으로 동작하도록 개선

## 🔗 관련 이슈

#57 

## 📷 참고 자료 (선택)

- Vercel 공식 문서: [https://vercel.com/docs](https://vercel.com/docs)

## 💬 기타

- 팀원이 PR을 생성해도 자동으로 Vercel에 배포되도록 설정
- 추가적인 환경 변수 수정은 `.vercel/project.json` 및 GitHub Secrets에서 관리

---

closes #57 
