### PR TITLE
Feature/63 user role change

### DIFF
--- a/src/components/ui/Modal/constants.ts
+++ b/src/components/ui/Modal/constants.ts
@@ -1,7 +1,7 @@
 import type { ModalPlacement, ModalSize } from '@/types'
 
 export const SIZE_CLASS: Record<ModalSize, string> = {
-  default: 'w-[672px] h-[710px]',
+  default: 'w-[672px]',
   xs: 'max-w-xs',
   sm: 'max-w-sm',
   md: 'max-w-md',

--- a/src/components/ui/Modal/feature/UserDetail.tsx
+++ b/src/components/ui/Modal/feature/UserDetail.tsx
@@ -132,7 +132,6 @@ export default function MemberDetailModal({
   data,
   onEdit,
   onDelete,
-  onChangeRole,
 }: {
   open: boolean
   onClose: () => void
@@ -178,8 +177,9 @@ export default function MemberDetailModal({
         <MemberDetailView m={form} editing={editing} onChange={handleChange} />
       </Modal.Body>
 
+      <div className="border-b border-gray-200" />
       {/* Footer */}
-      <Modal.Footer>
+      <Modal.Footer className="bg-gray-50 py-5">
         <div className="flex w-full justify-between">
           <Button
             btnStyle="success"

--- a/src/components/ui/Modal/feature/UserDetail.tsx
+++ b/src/components/ui/Modal/feature/UserDetail.tsx
@@ -2,6 +2,7 @@ import Modal from '../Modal'
 import { Button } from '../../Button'
 import { useState } from 'react'
 import Field from '../fields/Field'
+import UserRoleChange, { type UserRole } from './UserRoleChange'
 
 /** 도메인 타입 — 실제 필드/라벨 명칭에 맞게 수정 가능 */
 export type MemberDetail = {
@@ -142,6 +143,7 @@ export default function MemberDetailModal({
 }) {
   const [editing, setEditing] = useState(false)
   const [form, setForm] = useState<MemberDetail>(data)
+  const [roleModalOpen, setRoleModalOpen] = useState(false)
 
   const handleChange = (field: keyof MemberDetail, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }))
@@ -182,7 +184,16 @@ export default function MemberDetailModal({
           <Button
             btnStyle="success"
             btnText="권한 변경하기"
-            onClick={() => onChangeRole?.(data)}
+            onClick={() => setRoleModalOpen(true)}
+          />
+
+          <UserRoleChange
+            open={roleModalOpen}
+            value={(form.role as UserRole) || '일반회원'}
+            onClose={() => setRoleModalOpen(false)}
+            onConfirm={(nextRole) => {
+              setForm((prev) => ({ ...prev, role: nextRole }))
+            }}
           />
           <div className="flex gap-3">
             {editing ? (

--- a/src/components/ui/Modal/feature/UserRoleChange.tsx
+++ b/src/components/ui/Modal/feature/UserRoleChange.tsx
@@ -40,7 +40,12 @@ export default function UserRoleChange({
   }, [open, value])
 
   return (
-    <Modal open={open} onClose={onClose} className="w-[448px]">
+    <Modal
+      open={open}
+      onClose={onClose}
+      className="w-[448px]"
+      showCloseIcon={false}
+    >
       <Modal.Header>
         <Modal.Title>권한 변경</Modal.Title>
       </Modal.Header>

--- a/src/components/ui/Modal/feature/UserRoleChange.tsx
+++ b/src/components/ui/Modal/feature/UserRoleChange.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react'
+import Modal from '../Modal'
+import { Button } from '../../Button'
+
+export type UserRole = '관리자' | '스태프' | '일반회원'
+
+type UserRoleProps = {
+  open: boolean
+  /** 현재 권한 */
+  value: UserRole
+  /** 해당 롤 누를 시, 선택 권한 전달 */
+  onConfirm: (nextRole: UserRole) => void
+  /** 닫기 */
+  onClose: () => void
+  /** 저장 중 로딩 상태 ( 쓸 일 거의 없을 거 같음 ) */
+  confirming?: boolean
+}
+
+const ROLE_OPTIONS: UserRole[] = ['관리자', '스태프', '일반회원']
+
+export default function UserRoleChange({
+  open,
+  value,
+  onConfirm,
+  onClose,
+  confirming = false,
+}: UserRoleProps) {
+  const [selected, setSelected] = useState<UserRole>(value)
+
+  // 열릴 때마다 현재 값으로 세팅
+  useEffect(() => {
+    if (open) setSelected(value)
+  }, [open, value])
+
+  return (
+    <Modal open={open} onClose={onClose} className="w-[448px]">
+      <Modal.Header>
+        <Modal.Title>권한 변경</Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body className="py-0">
+        <div className="space-y-3">
+          {ROLE_OPTIONS.map((role) => {
+            const isSelected = selected === role
+            return (
+              <Button
+                key={role}
+                btnStyle={isSelected ? 'primary' : 'secondary'}
+                btnSize="large"
+                btnText={role}
+                className="w-full justify-start rounded-2xl px-5 py-4"
+                disabled={confirming}
+                onClick={() => {
+                  setSelected(role)
+                  onConfirm(role)
+                  onClose()
+                }}
+              />
+            )
+          })}
+        </div>
+      </Modal.Body>
+
+      <Modal.Footer align="end" className="mt-0">
+        <div className="flex gap-2">
+          <Button
+            btnStyle="secondary"
+            btnText="취소"
+            onClick={onClose}
+            disabled={confirming}
+          />
+        </div>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/src/components/ui/Modal/feature/UserRoleChange.tsx
+++ b/src/components/ui/Modal/feature/UserRoleChange.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import Modal from '../Modal'
 import { Button } from '../../Button'
+import { cn } from '@/lib'
 
 export type UserRole = '관리자' | '스태프' | '일반회원'
 
@@ -17,6 +18,12 @@ type UserRoleProps = {
 }
 
 const ROLE_OPTIONS: UserRole[] = ['관리자', '스태프', '일반회원']
+const ROLE_SELECTED = {
+  base: 'w-full justify-start rounded-2xl px-5 py-4',
+  default:
+    'text-secondary-text bg-white shadow-[inset_0_0_0_1px_#d1d5db] hover:bg-gray-50',
+  selected: 'text-primary-blue bg-blue-50 shadow-[inset_0_0_0_1px_#93c5fd]',
+} as const
 
 export default function UserRoleChange({
   open,
@@ -45,10 +52,13 @@ export default function UserRoleChange({
             return (
               <Button
                 key={role}
-                btnStyle={isSelected ? 'primary' : 'secondary'}
+                btnStyle="secondary"
                 btnSize="large"
                 btnText={role}
-                className="w-full justify-start rounded-2xl px-5 py-4"
+                className={cn(
+                  ROLE_SELECTED.base,
+                  isSelected ? ROLE_SELECTED.selected : ROLE_SELECTED.default
+                )}
                 disabled={confirming}
                 onClick={() => {
                   setSelected(role)

--- a/src/components/ui/Modal/feature/UserRoleChange.tsx
+++ b/src/components/ui/Modal/feature/UserRoleChange.tsx
@@ -21,8 +21,8 @@ const ROLE_OPTIONS: UserRole[] = ['관리자', '스태프', '일반회원']
 const ROLE_SELECTED = {
   base: 'w-full justify-start rounded-2xl px-5 py-4',
   default:
-    'text-secondary-text bg-white shadow-[inset_0_0_0_1px_#d1d5db] hover:bg-gray-50',
-  selected: 'text-primary-blue bg-blue-50 shadow-[inset_0_0_0_1px_#93c5fd]',
+    'text-primary-text bg-white shadow-[inset_0_0_0_1px_#e5e7eb] hover:bg-gray-50',
+  selected: 'text-primary-blue bg-[#EFF6FF] shadow-[inset_0_0_0_1px_#93c5fd]',
 } as const
 
 export default function UserRoleChange({

--- a/src/components/ui/Modal/parts/Body.tsx
+++ b/src/components/ui/Modal/parts/Body.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { cn } from '@/lib' // cn 유틸 경로에 맞춰 조정
+import { cn } from '@/lib'
 
 export default function Body({
   children,

--- a/src/components/ui/Modal/parts/Footer.tsx
+++ b/src/components/ui/Modal/parts/Footer.tsx
@@ -1,18 +1,21 @@
 export default function Footer({
   children,
   align = 'end',
+  className = '',
 }: {
   children: React.ReactNode
   align?: 'start' | 'center' | 'end'
+  className?: string
 }) {
   const map = {
     start: 'justify-start',
     center: 'justify-center',
     end: 'justify-end',
   } as const
+
   return (
     <div
-      className={`mt-auto flex items-center ${map[align]} gap-2 border-t border-gray-200 bg-gray-50 px-6 py-4`}
+      className={`flex items-center ${map[align]} gap-2 px-6 py-4 ${className}`}
     >
       {children}
     </div>

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -97,7 +97,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
           <button
             type="button"
             onClick={() => setShowPw((v) => !v)}
-            className={cn(`absolute inset-y-0 flex items-center pr-3`)}
+            className={cn(`absolute inset-y-0 right-0 flex items-center pr-3`)}
             aria-label={showPw ? '비밀번호 숨기기' : '비밀번호 표시'}
             tabIndex={-1}
           >


### PR DESCRIPTION
## 📌 개요

Modal 컴포넌트에 닫기 아이콘 표시 여부를 제어할 수 있는 옵션(`showCloseIcon`)을 추가하여,  
사용자가 필요에 따라 닫기 아이콘을 숨기거나 보이도록 설정할 수 있게 수정했습니다.

---

## ✅ 변경 사항

- [x] `Modal` 컴포넌트에 `showCloseIcon` prop 추가 (기본값: `true`)
- [x] `showCloseIcon={false}`일 경우 닫기 아이콘 비표시
- [x] 기존 기본 동작(닫기 아이콘 항상 표시)은 그대로 유지

---

## 🔗 관련 이슈

closes #63

---

## 📷 참고 자료 (선택)
<img width="738" height="754" alt="image" src="https://github.com/user-attachments/assets/c651889c-1035-465a-94ee-e5e9d327a208" />

- Modal 사용 예시:
  ```tsx
  <Modal open={open} onClose={onClose} showCloseIcon={false}>
    <Modal.Header>
      <Modal.Title>권한 변경</Modal.Title>
    </Modal.Header>
    <Modal.Body>...</Modal.Body>
  </Modal>
