### PR TITLE
Feature/70 user delete

### DIFF
--- a/src/components/ui/Modal/feature/UserDelete.tsx
+++ b/src/components/ui/Modal/feature/UserDelete.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+import { Button } from '../../Button'
+import Modal from '../Modal'
+
+type UserDeleteProps = {
+  open: boolean
+  userId: string
+  /** 삭제 */
+  deleteUser: (userId: string) => Promise<void>
+  /** 닫기 */
+  onClose: () => void
+  /** 삭제 성공 후 알림 */
+  onDeleted?: () => void
+}
+
+export default function UserDelete({
+  open,
+  userId,
+  deleteUser,
+  onClose,
+  onDeleted,
+}: UserDeleteProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const descId = 'user-delete-desc'
+
+  const handleDelete = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      await deleteUser(userId)
+      onDeleted?.()
+      onClose()
+    } catch (error) {
+      setError(`${error}, 삭제 중 오류 발생!! 잠시 후 다시 시도해주세요.`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      className="w-[448px]"
+      showCloseIcon={false}
+      describedById={descId}
+    >
+      <Modal.Header className="mt-2">
+        <Modal.Title>회원 삭제 확인</Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body className="py-0">
+        <div id={descId} className="text-[16px] text-gray-600">
+          삭제 시 해당 유저와 관련된 모든 데이터가 즉시 삭제되며 되돌릴 수
+          없습니다.
+        </div>
+        {error && (
+          <p role="alert" className="mt-3 text-sm text-red-600">
+            {error}
+          </p>
+        )}
+      </Modal.Body>
+
+      <Modal.Footer align="end" className="mb-1">
+        <div className="flex gap-3">
+          <Button
+            btnStyle="secondary"
+            btnText="취소"
+            onClick={onClose}
+            disabled={loading}
+          />
+          <Button
+            btnStyle="danger"
+            btnText={loading ? '삭제 중…' : '삭제'}
+            onClick={handleDelete}
+            disabled={loading}
+          />
+        </div>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/src/components/ui/Modal/feature/UserDetail.tsx
+++ b/src/components/ui/Modal/feature/UserDetail.tsx
@@ -3,6 +3,7 @@ import { Button } from '../../Button'
 import { useState } from 'react'
 import Field from '../fields/Field'
 import UserRoleChange, { type UserRole } from './UserRoleChange'
+import UserDelete from './UserDelete'
 
 /** 도메인 타입 — 실제 필드/라벨 명칭에 맞게 수정 가능 */
 export type MemberDetail = {
@@ -131,18 +132,23 @@ export default function MemberDetailModal({
   onClose,
   data,
   onEdit,
-  onDelete,
 }: {
   open: boolean
   onClose: () => void
   data: MemberDetail
   onEdit?: (m: MemberDetail) => void
-  onDelete?: (m: MemberDetail) => void
-  onChangeRole?: (m: MemberDetail) => void
 }) {
   const [editing, setEditing] = useState(false)
   const [form, setForm] = useState<MemberDetail>(data)
   const [roleModalOpen, setRoleModalOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  // 실제 삭제 함수 (추후 API 연동)
+  const deleteUser = async (userId: string) => {
+    // TODO: 서버 API 호출로 교체
+    // await api.delete(`/users/${userId}`)
+    await new Promise((r) => setTimeout(r, 500)) // 데모용
+  }
 
   const handleChange = (field: keyof MemberDetail, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }))
@@ -220,13 +226,24 @@ export default function MemberDetailModal({
                 <Button
                   btnStyle="danger"
                   btnText="삭제하기"
-                  onClick={() => onDelete?.(data)}
+                  onClick={() => setDeleteOpen(true)}
                 />
               </>
             )}
           </div>
         </div>
       </Modal.Footer>
+
+      <UserDelete
+        open={deleteOpen}
+        userId={form.id}
+        deleteUser={deleteUser}
+        onClose={() => setDeleteOpen(false)}
+        onDeleted={() => {
+          // 삭제 성공 후, 토스트 띄우고 목록으로 복귀
+          onClose()
+        }}
+      />
     </Modal>
   )
 }

--- a/src/components/ui/Modal/feature/UserDetail.tsx
+++ b/src/components/ui/Modal/feature/UserDetail.tsx
@@ -144,7 +144,8 @@ export default function MemberDetailModal({
   const [deleteOpen, setDeleteOpen] = useState(false)
 
   // 실제 삭제 함수 (추후 API 연동)
-  const deleteUser = async (userId: string) => {
+  //const deleteUser = async (userId: string) => {
+  const deleteUser = async () => {
     // TODO: 서버 API 호출로 교체
     // await api.delete(`/users/${userId}`)
     await new Promise((r) => setTimeout(r, 500)) // 데모용

--- a/src/components/ui/Modal/parts/Header.tsx
+++ b/src/components/ui/Modal/parts/Header.tsx
@@ -1,6 +1,14 @@
-export default function Header({ children }: { children: React.ReactNode }) {
+export default function Header({
+  children,
+  className = '',
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
   return (
-    <div className="body-sm flex items-center justify-between px-6 py-4 font-medium">
+    <div
+      className={`body-sm ${className} flex items-center justify-between px-6 py-4 font-medium`}
+    >
       {children}
     </div>
   )

--- a/src/test-pages/UserDetailModalTest.tsx
+++ b/src/test-pages/UserDetailModalTest.tsx
@@ -35,8 +35,6 @@ export default function TestMemberDetailPage() {
         onClose={() => setOpen(false)}
         data={mockMember}
         onEdit={(m) => alert(`EDIT: ${JSON.stringify(m)}`)}
-        onDelete={(m) => alert(`DELETE: ${m.id}`)}
-        onChangeRole={(m) => alert(`CHANGE ROLE: ${m.id}`)}
       />
     </div>
   )


### PR DESCRIPTION
## 📌 개요

회원 삭제 기능을 위한 `UserDelete` 모달을 구현하고, `MemberDetailModal`과 연동했습니다.  
삭제 시 확인 모달이 표시되며, 실제 삭제 로직은 `UserDelete` 내부에서 수행됩니다.

---

## ✅ 변경 사항

- [x] `UserDelete` 모달 컴포넌트 추가
  - 삭제 확인 메시지와 취소/삭제 버튼 제공
  - `deleteUser(userId)` 호출로 실제 삭제 수행
  - 로딩/에러 상태 관리 및 접근성(`aria-describedby`) 보강
- [x] `MemberDetailModal`에 `UserDelete` 연동
  - "삭제하기" 버튼 클릭 시 확인 모달 표시
  - 삭제 성공 시 부모 콜백(`onDeleted`) 실행 및 모달 닫기
- [x] 삭제 중 버튼 비활성화 및 에러 메시지 표시 추가

---

## 🔗 관련 이슈

closes #70 

---

## 📷 참고 자료 (선택)

- 삭제 확인 모달 예시 화면  
<img width="711" height="732" alt="image" src="https://github.com/user-attachments/assets/bbdbc206-a8b8-4a08-a9cd-3a02b94a88be" />

---

## 💬 기타

- 현재 `deleteUser`는 데모용으로 `setTimeout`을 사용했으며, 실제 환경에서는 API 연동 코드로 교체해야 합니다.
- `onDeleted` 콜백을 활용해 부모에서 리스트 리프레시, 상세 모달 닫기 등의 후처리를 할 수 있습니다.
