### PR TITLE
[Feat]/79 withdrawal detail

### DIFF
--- a/docs/Skeleton-사용법.md
+++ b/docs/Skeleton-사용법.md
@@ -1,0 +1,33 @@
+# 📘 Skeleton 컴포넌트 사용법
+
+## 📌 개요
+
+`Skeleton` 컴포넌트는 데이터 로딩 상태에서 실제 콘텐츠 대신 **뼈대 UI**를 보여주는 프레젠테이션 컴포넌트.  
+사용자는 로딩 중임을 직관적으로 인지할 수 있고, 레이아웃 점프 없이 부드럽게 실제 UI로 전환됨.
+
+---
+
+## 📦 설치 / 위치
+
+- 파일 위치: `src/components/ui/Skeleton.tsx`
+- 별도의 의존성 없음 (Tailwind CSS 기반)
+
+---
+
+## 🛠 사용 방법
+
+### 1. 기본 사용
+
+```tsx
+import Skeleton from '@/components/ui/Skeleton'
+
+export default function ProfilePage() {
+  const { data, isLoading } = useUserDetail()
+
+  return (
+    <section aria-busy={isLoading ? 'true' : 'false'}>
+      {isLoading ? <Skeleton /> : <ProfileDetail data={data} />}
+    </section>
+  )
+}
+```

--- a/src/components/ui/Modal/constants.ts
+++ b/src/components/ui/Modal/constants.ts
@@ -10,6 +10,7 @@ export const SIZE_CLASS: Record<ModalSize, string> = {
   '2xl': 'max-w-2xl',
   '3xl': 'max-w-3xl',
   full: 'w-screen h-screen max-w-none',
+  none: '',
 }
 
 export const PLACEMENT_CLASS: Record<ModalPlacement, string> = {

--- a/src/components/ui/Modal/feature/User/UserDetail.tsx
+++ b/src/components/ui/Modal/feature/User/UserDetail.tsx
@@ -1,10 +1,11 @@
 import Modal from '../../Modal'
 import { Button } from '../../../Button'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import UserRoleChange, { type UserRole } from './UserRoleChange'
 import UserDelete from './UserDelete'
 import type { UserDetail } from './User.types'
 import UserDetailView from './UserDetailView'
+import { useFormHandlers } from '@/hooks/useFormHandlers'
 
 /** 도메인 타입 — 실제 필드/라벨 명칭에 맞게 수정 가능 */
 
@@ -20,8 +21,17 @@ export default function UserDetailModal({
   data: UserDetail
   onEdit?: (m: UserDetail) => void
 }) {
-  const [editing, setEditing] = useState(false)
-  const [form, setForm] = useState<UserDetail>(data)
+  const {
+    form,
+    setForm,
+    editing,
+    setEditing,
+    handleChange,
+    handleSave,
+    handleCancel,
+    resetForm,
+  } = useFormHandlers<UserDetail>(data, { onEdit })
+
   const [roleModalOpen, setRoleModalOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
 
@@ -32,20 +42,10 @@ export default function UserDetailModal({
     // await api.delete(`/users/${userId}`)
     await new Promise((r) => setTimeout(r, 500)) // 데모용
   }
-
-  const handleChange = (field: keyof UserDetail, value: string) => {
-    setForm((prev) => ({ ...prev, [field]: value }))
-  }
-
-  const handleSave = () => {
-    onEdit?.(form)
-    setEditing(false)
-  }
-
-  const handleCancel = () => {
-    setForm(data)
-    setEditing(false)
-  }
+  // data prop이 바뀔 때 form 동기화
+  useEffect(() => {
+    resetForm(data)
+  }, [data, resetForm])
 
   return (
     <Modal
@@ -58,7 +58,7 @@ export default function UserDetailModal({
     >
       {/* Header */}
       <Modal.Header>
-        <Modal.Title>회원 상세 정보</Modal.Title>
+        <Modal.Title id="user-title">회원 상세 정보</Modal.Title>
       </Modal.Header>
       <div className="border-b border-gray-200" />
       {/* Body */}

--- a/src/components/ui/Modal/feature/Withdrawal/Withdrawal.types.ts
+++ b/src/components/ui/Modal/feature/Withdrawal/Withdrawal.types.ts
@@ -1,0 +1,16 @@
+export type WithdrawalDetail = {
+  id: string
+  name: string
+  email: string
+  gender?: '남성' | '여성' | '기타' | '미기입' | string
+  nickname?: string
+  role: '일반회원' | '관리자' | '스태프' | string
+  status: '활성' | '비활성' | '탈퇴요청' | '삭제예정' | string
+  joinedAt?: string // ISO
+  withdrawalRequestId: string
+  requestedAt: string // ISO
+  scheduledDeletionAt?: string // ISO
+  reason?: string
+  reasonDetail?: string
+  avatarUrl?: string
+}

--- a/src/components/ui/Modal/feature/Withdrawal/WithdrawalDetail.tsx
+++ b/src/components/ui/Modal/feature/Withdrawal/WithdrawalDetail.tsx
@@ -49,7 +49,7 @@ export default function WithdrawalModal({
       <div className="border-b border-gray-200" />
 
       {/* Body: 상세 뷰 조립 */}
-      <Modal.Body className="p-0">
+      <Modal.Body className="max-h-[65vh] p-0">
         <WithdrawalDetailView
           form={form}
           loading={loading}

--- a/src/components/ui/Modal/feature/Withdrawal/WithdrawalDetail.tsx
+++ b/src/components/ui/Modal/feature/Withdrawal/WithdrawalDetail.tsx
@@ -1,0 +1,193 @@
+import Modal from '../../Modal'
+import { Button } from '../../../Button'
+import { useFormHandlers } from '@/hooks/useFormHandlers'
+import type { WithdrawalDetail } from './Withdrawal.types'
+import { useEffect } from 'react'
+import Skeleton from '@/components/ui/Skeleton'
+import Field from '../../fields/Field'
+import { formatDateTime } from '@/lib/datetime'
+
+type WithdrawalProps = {
+  open: boolean
+  data?: WithdrawalDetail | null
+  loading?: boolean
+  errorText?: string | null
+  onClose: () => void
+  onRequestRestore?: (detail: WithdrawalDetail) => void
+}
+
+export default function WithdrawalModal({
+  open,
+  data,
+  loading,
+  errorText,
+  onClose,
+  onRequestRestore,
+}: WithdrawalProps) {
+  const { form, resetForm, restoring, handleRestore } =
+    useFormHandlers<WithdrawalDetail>(
+      (data as WithdrawalDetail) || ({} as WithdrawalDetail),
+      { onRestore: onRequestRestore }
+    )
+
+  // 외부 data 변경 시 동기화
+  useEffect(() => {
+    if (data) resetForm(data)
+  }, [data, resetForm])
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="none"
+      className="w-[768px]"
+      maxHeightClass=""
+    >
+      {/* Header */}
+      <Modal.Header>
+        <Modal.Title id="withdrawal-title">회원 탈퇴 상세 정보</Modal.Title>
+      </Modal.Header>
+      <div className="border-b border-gray-200" />
+
+      {/* Body 1 */}
+      <Modal.Header>
+        <Modal.Title>회원 정보</Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="pt-0 pb-3">
+        {loading && <Skeleton />}
+
+        {!loading && errorText && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {errorText}
+          </div>
+        )}
+
+        {!loading && !errorText && form && (
+          <div className="space-y-8">
+            {/* 상단 프로필 */}
+            <div className="flex items-center gap-4">
+              <img
+                src={form.avatarUrl || 'https://placehold.co/80x80?text=👤'}
+                alt={`${form.name ?? ''} 프로필 이미지`}
+                className="size-20 rounded-full object-cover"
+              />
+              <div>
+                <h4 className="text-lg font-semibold">{form.name ?? '-'}</h4>
+                <div className="text-gray-500">{form.email ?? '-'}</div>
+              </div>
+            </div>
+
+            {/* 그리드 정보 */}
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {/* 회원 정보 */}
+
+              {/* Field: 읽기전용 */}
+              <Field
+                label="이름"
+                value={form.name}
+                editing={false}
+                onChange={() => {}}
+              />
+              <Field
+                label="닉네임"
+                value={form.nickname ?? ''}
+                editing={false}
+                onChange={() => {}}
+              />
+              <Field
+                label="권한"
+                value={form.role ?? ''}
+                editing={false}
+                onChange={() => {}}
+              />
+              <Field
+                label="성별"
+                value={form.gender ?? '미기입'}
+                editing={false}
+                onChange={() => {}}
+              />
+              {/* 상태는 커스텀 렌더 → 아래처럼 배지와 함께 별도 표현 */}
+              <Field
+                label="상태"
+                value={form.status ?? ''}
+                editing={false}
+                onChange={() => {}}
+              />
+              <Field
+                label="이메일"
+                value={form.email ?? ''}
+                editing={false}
+                onChange={() => {}}
+              />
+              <Field
+                label="회원가입 일시"
+                value={formatDateTime(form.joinedAt)}
+                editing={false}
+                onChange={() => {}}
+              />
+            </div>
+          </div>
+        )}
+      </Modal.Body>
+
+      {/* Body 1 */}
+      {/* 탈퇴 정보 */}
+      <Modal.Header className="pb-2">
+        <Modal.Title>탈퇴 정보</Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="pt-0">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Field
+            label="탈퇴요청 고유 ID"
+            value={form.withdrawalRequestId ?? ''}
+            editing={false}
+            onChange={() => {}}
+          />
+          <Field
+            label="탈퇴요청 일시"
+            value={formatDateTime(form.requestedAt)}
+            editing={false}
+            onChange={() => {}}
+          />
+          <Field
+            label="삭제 예정 일시"
+            value={formatDateTime(form.scheduledDeletionAt)}
+            editing={false}
+            onChange={() => {}}
+          />
+          <Field
+            label="탈퇴사유"
+            value={form.reason ?? ''}
+            editing={false}
+            onChange={() => {}}
+          />
+        </div>
+      </Modal.Body>
+
+      <Modal.Body className="pt-0">
+        {/* 상세사유는 멀티라인 표시 */}
+        <Field
+          label="탈퇴 상세 사유"
+          value={form.reasonDetail || '-'}
+          editing={false}
+          onChange={() => {}}
+        />
+      </Modal.Body>
+
+      <div className="border-b border-gray-200" />
+      {/* Footer */}
+      <Modal.Footer align="end" className="bg-gray-50">
+        <Modal.Actions>
+          <Button btnStyle="secondary" btnText="닫기" onClick={onClose} />
+          <Button
+            btnStyle="success"
+            btnText={restoring ? '복구 중...' : '회원 복구하기'}
+            onClick={handleRestore}
+            disabled={!form || restoring}
+            aria-disabled={!form || restoring}
+          />
+        </Modal.Actions>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/src/components/ui/Modal/feature/Withdrawal/WithdrawalDetail.tsx
+++ b/src/components/ui/Modal/feature/Withdrawal/WithdrawalDetail.tsx
@@ -3,9 +3,7 @@ import { Button } from '../../../Button'
 import { useFormHandlers } from '@/hooks/useFormHandlers'
 import type { WithdrawalDetail } from './Withdrawal.types'
 import { useEffect } from 'react'
-import Skeleton from '@/components/ui/Skeleton'
-import Field from '../../fields/Field'
-import { formatDateTime } from '@/lib/datetime'
+import WithdrawalDetailView from './WithdrawalDetailView'
 
 type WithdrawalProps = {
   open: boolean
@@ -43,134 +41,19 @@ export default function WithdrawalModal({
       className="w-[768px]"
       maxHeightClass=""
     >
-      {/* Header */}
+      {/* Section 1 */}
+      {/* Header 1 */}
       <Modal.Header>
         <Modal.Title id="withdrawal-title">회원 탈퇴 상세 정보</Modal.Title>
       </Modal.Header>
       <div className="border-b border-gray-200" />
 
-      {/* Body 1 */}
-      <Modal.Header>
-        <Modal.Title>회원 정보</Modal.Title>
-      </Modal.Header>
-      <Modal.Body className="pt-0 pb-3">
-        {loading && <Skeleton />}
-
-        {!loading && errorText && (
-          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-            {errorText}
-          </div>
-        )}
-
-        {!loading && !errorText && form && (
-          <div className="space-y-8">
-            {/* 상단 프로필 */}
-            <div className="flex items-center gap-4">
-              <img
-                src={form.avatarUrl || 'https://placehold.co/80x80?text=👤'}
-                alt={`${form.name ?? ''} 프로필 이미지`}
-                className="size-20 rounded-full object-cover"
-              />
-              <div>
-                <h4 className="text-lg font-semibold">{form.name ?? '-'}</h4>
-                <div className="text-gray-500">{form.email ?? '-'}</div>
-              </div>
-            </div>
-
-            {/* 그리드 정보 */}
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              {/* 회원 정보 */}
-
-              {/* Field: 읽기전용 */}
-              <Field
-                label="이름"
-                value={form.name}
-                editing={false}
-                onChange={() => {}}
-              />
-              <Field
-                label="닉네임"
-                value={form.nickname ?? ''}
-                editing={false}
-                onChange={() => {}}
-              />
-              <Field
-                label="권한"
-                value={form.role ?? ''}
-                editing={false}
-                onChange={() => {}}
-              />
-              <Field
-                label="성별"
-                value={form.gender ?? '미기입'}
-                editing={false}
-                onChange={() => {}}
-              />
-              {/* 상태는 커스텀 렌더 → 아래처럼 배지와 함께 별도 표현 */}
-              <Field
-                label="상태"
-                value={form.status ?? ''}
-                editing={false}
-                onChange={() => {}}
-              />
-              <Field
-                label="이메일"
-                value={form.email ?? ''}
-                editing={false}
-                onChange={() => {}}
-              />
-              <Field
-                label="회원가입 일시"
-                value={formatDateTime(form.joinedAt)}
-                editing={false}
-                onChange={() => {}}
-              />
-            </div>
-          </div>
-        )}
-      </Modal.Body>
-
-      {/* Body 1 */}
-      {/* 탈퇴 정보 */}
-      <Modal.Header className="pb-2">
-        <Modal.Title>탈퇴 정보</Modal.Title>
-      </Modal.Header>
-      <Modal.Body className="pt-0">
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <Field
-            label="탈퇴요청 고유 ID"
-            value={form.withdrawalRequestId ?? ''}
-            editing={false}
-            onChange={() => {}}
-          />
-          <Field
-            label="탈퇴요청 일시"
-            value={formatDateTime(form.requestedAt)}
-            editing={false}
-            onChange={() => {}}
-          />
-          <Field
-            label="삭제 예정 일시"
-            value={formatDateTime(form.scheduledDeletionAt)}
-            editing={false}
-            onChange={() => {}}
-          />
-          <Field
-            label="탈퇴사유"
-            value={form.reason ?? ''}
-            editing={false}
-            onChange={() => {}}
-          />
-        </div>
-      </Modal.Body>
-
-      <Modal.Body className="pt-0">
-        {/* 상세사유는 멀티라인 표시 */}
-        <Field
-          label="탈퇴 상세 사유"
-          value={form.reasonDetail || '-'}
-          editing={false}
-          onChange={() => {}}
+      {/* Body: 상세 뷰 조립 */}
+      <Modal.Body className="p-0">
+        <WithdrawalDetailView
+          form={form}
+          loading={loading}
+          errorText={errorText}
         />
       </Modal.Body>
 

--- a/src/components/ui/Modal/feature/Withdrawal/WithdrawalDetailView.tsx
+++ b/src/components/ui/Modal/feature/Withdrawal/WithdrawalDetailView.tsx
@@ -1,0 +1,54 @@
+import Skeleton from '@/components/ui/Skeleton'
+import WithdrawalUserView from './WithdrawalUserView'
+import WithdrawalInfoView from './WithdrawalInfoView'
+import type { WithdrawalDetail } from './Withdrawal.types'
+
+type Props = {
+  form?: WithdrawalDetail | null
+  loading?: boolean
+  errorText?: string | null
+}
+
+export default function WithdrawalDetailView({
+  form,
+  loading,
+  errorText,
+}: Props) {
+  if (loading) {
+    return (
+      <div className="px-6">
+        <Skeleton />
+      </div>
+    )
+  }
+
+  if (errorText) {
+    return (
+      <div className="px-6">
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {errorText}
+        </div>
+      </div>
+    )
+  }
+
+  if (!form) {
+    return (
+      <div className="px-6">
+        <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+          표시할 데이터가 없습니다.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {/* Section 1: 회원 정보 */}
+      <WithdrawalUserView form={form} />
+
+      {/* Section 2: 탈퇴 정보 */}
+      <WithdrawalInfoView form={form} />
+    </>
+  )
+}

--- a/src/components/ui/Modal/feature/Withdrawal/WithdrawalInfoView.tsx
+++ b/src/components/ui/Modal/feature/Withdrawal/WithdrawalInfoView.tsx
@@ -1,0 +1,64 @@
+import Field from '../../fields/Field'
+import Modal from '../../Modal'
+import type { WithdrawalDetail } from './Withdrawal.types'
+import { formatDateTime } from '@/lib/datetime'
+import { memo } from 'react'
+
+type Props = {
+  form: WithdrawalDetail
+}
+
+function WithdrawalInfoViewBase({ form }: Props) {
+  return (
+    <>
+      {/* Header */}
+      <Modal.Header className="pb-2">
+        <Modal.Title>탈퇴 정보</Modal.Title>
+      </Modal.Header>
+
+      {/* Body: 기본 필드 */}
+      <Modal.Body className="pt-0 pb-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Field
+            label="탈퇴요청 고유 ID"
+            value={form.withdrawalRequestId ?? ''}
+            editing={false}
+            onChange={() => {}}
+          />
+          <Field
+            label="탈퇴요청 일시"
+            value={formatDateTime(form.requestedAt)}
+            editing={false}
+            onChange={() => {}}
+          />
+          <Field
+            label="삭제 예정 일시"
+            value={formatDateTime(form.scheduledDeletionAt)}
+            editing={false}
+            onChange={() => {}}
+          />
+          <Field
+            label="탈퇴사유"
+            value={form.reason ?? ''}
+            editing={false}
+            onChange={() => {}}
+          />
+        </div>
+      </Modal.Body>
+      {/* Body: 상세 사유 */}
+      <div className="px-6 pt-0 pb-6">
+        <Field
+          label="탈퇴 상세 사유"
+          value={form.reasonDetail || '-'}
+          editing={false}
+          onChange={() => {}}
+        />
+      </div>
+
+      <div className="border-b border-gray-200" />
+    </>
+  )
+}
+
+const WithdrawalInfoView = memo(WithdrawalInfoViewBase)
+export default WithdrawalInfoView

--- a/src/components/ui/Modal/feature/Withdrawal/WithdrawalUserView.tsx
+++ b/src/components/ui/Modal/feature/Withdrawal/WithdrawalUserView.tsx
@@ -1,0 +1,87 @@
+import { formatDateTime } from '@/lib/datetime'
+import Field from '../../fields/Field'
+import Modal from '../../Modal'
+import type { WithdrawalDetail } from './Withdrawal.types'
+import { memo } from 'react'
+
+type Props = {
+  form: WithdrawalDetail
+}
+
+function WithdrawalUserViewBase({ form }: Props) {
+  return (
+    <>
+      {/* Header */}
+      <Modal.Header className="pb-0">
+        <Modal.Title>회원 정보</Modal.Title>
+      </Modal.Header>
+
+      {/* Body */}
+      <Modal.Body className="pt-0 pb-3">
+        <div className="space-y-8">
+          {/* 상단 프로필 */}
+          <div className="mb-5 flex items-center gap-4">
+            <img
+              src={form.avatarUrl || 'https://placehold.co/80x80?text=👤'}
+              alt={`${form.name ?? ''} 프로필 이미지`}
+              className="size-20 rounded-full object-cover"
+            />
+            <div>
+              <h4 className="text-lg font-semibold">{form.name ?? '-'}</h4>
+              <div className="text-gray-500">{form.email ?? '-'}</div>
+            </div>
+          </div>
+
+          {/* 그리드 정보 */}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <Field
+              label="이름"
+              value={form.name ?? ''}
+              editing={false}
+              onChange={() => {}}
+            />
+            <Field
+              label="성별"
+              value={form.gender ?? '미기입'}
+              editing={false}
+              onChange={() => {}}
+            />
+            <Field
+              label="닉네임"
+              value={form.nickname ?? ''}
+              editing={false}
+              onChange={() => {}}
+            />
+            <Field
+              label="이메일"
+              value={form.email ?? ''}
+              editing={false}
+              onChange={() => {}}
+            />
+            <Field
+              label="권한"
+              value={form.role ?? ''}
+              editing={false}
+              onChange={() => {}}
+            />
+            <Field
+              label="상태"
+              value={form.status ?? ''}
+              editing={false}
+              onChange={() => {}}
+            />
+            <Field
+              label="회원가입 일시"
+              value={formatDateTime(form.joinedAt)}
+              editing={false}
+              onChange={() => {}}
+            />
+          </div>
+        </div>
+      </Modal.Body>
+    </>
+  )
+}
+
+const WithdrawalUserView = memo(WithdrawalUserViewBase)
+export default WithdrawalUserView

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,21 @@
+export default function Skeleton() {
+  return (
+    <div className="animate-pulse space-y-8">
+      <div className="flex items-center gap-4">
+        <div className="size-20 rounded-full bg-gray-200" />
+        <div className="space-y-2">
+          <div className="h-5 w-40 rounded bg-gray-200" />
+          <div className="h-4 w-56 rounded bg-gray-200" />
+        </div>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <div className="h-3 w-24 rounded bg-gray-200" />
+            <div className="h-10 w-full rounded bg-gray-200" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useFormHandlers.ts
+++ b/src/hooks/useFormHandlers.ts
@@ -1,0 +1,96 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+type EditFn<T> = (data: T) => void
+type Options<T> = { onEdit?: EditFn<T>; onRestore?: EditFn<T> }
+
+// ── Overloads ────────────────────────────────────────────────────────────────
+export function useFormHandlers<T>(initialData: T, onEdit: EditFn<T>): Return<T>
+export function useFormHandlers<T>(
+  initialData: T,
+  options?: Options<T>
+): Return<T>
+
+// ── Impl ────────────────────────────────────────────────────────────────────
+export function useFormHandlers<T>(
+  initialData: T,
+  second?: EditFn<T> | Options<T>
+): Return<T> {
+  // 옵션 정규화 (함수/객체 모두 허용)
+  const opts = useMemo<Options<T>>(() => {
+    if (typeof second === 'function') return { onEdit: second }
+    return second ?? {}
+  }, [second])
+
+  // 최초 props를 보관 (취소 시 되돌릴 기준)
+  const initialRef = useRef<T>(initialData)
+
+  const [form, setForm] = useState<T>(initialData)
+  const [editing, setEditing] = useState(false)
+  const [restoring, setRestoring] = useState(false)
+
+  /** 외부로부터 초기값이 바뀐 경우, 기준값 갱신 + 폼 리셋 */
+  const resetForm = useCallback((next: T) => {
+    initialRef.current = next
+    setForm(next)
+  }, [])
+
+  /** 필드 변경 (타입 안전) */
+  const handleChange = useCallback(
+    <K extends keyof T>(field: K, value: T[K]) => {
+      setForm((prev) => ({ ...prev, [field]: value }))
+    },
+    []
+  )
+
+  /** 저장 */
+  const handleSave = useCallback(() => {
+    opts.onEdit?.(form)
+    setEditing(false)
+  }, [form, opts])
+
+  /** 취소 → 최초 기준으로 되돌림 */
+  const handleCancel = useCallback(() => {
+    setForm(initialRef.current)
+    setEditing(false)
+  }, [])
+
+  /** 복구(회원 탈퇴 → 복구 등) */
+  const handleRestore = useCallback(() => {
+    if (restoring) return
+    setRestoring(true)
+    try {
+      opts.onRestore?.(form)
+    } finally {
+      setRestoring(false)
+    }
+  }, [form, opts, restoring])
+
+  return {
+    form,
+    setForm,
+    editing,
+    setEditing,
+    restoring,
+    setRestoring,
+    handleChange,
+    handleSave,
+    handleCancel,
+    resetForm,
+    handleRestore,
+  }
+}
+
+// 반환 타입 유틸 (추론 편의)
+type Return<T> = {
+  form: T
+  setForm: React.Dispatch<React.SetStateAction<T>>
+  editing: boolean
+  setEditing: React.Dispatch<React.SetStateAction<boolean>>
+  restoring: boolean
+  setRestoring: React.Dispatch<React.SetStateAction<boolean>>
+  handleChange: <K extends keyof T>(field: K, value: T[K]) => void
+  handleSave: () => void
+  handleCancel: () => void
+  resetForm: (next: T) => void
+  handleRestore: () => void
+}

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,0 +1,18 @@
+/** ISO → ko-KR 표시용 (UI 전용) */
+export function formatDateTime(iso?: string) {
+  if (!iso) return '-'
+  try {
+    const d = new Date(iso)
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: true,
+    }).format(d)
+  } catch {
+    return iso
+  }
+}

--- a/src/test-pages/WithdrawalModalTest.tsx
+++ b/src/test-pages/WithdrawalModalTest.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@/components/ui/Button'
+import type { WithdrawalDetail } from '@/components/ui/Modal/feature/Withdrawal/Withdrawal.types'
+import WithdrawalModal from '@/components/ui/Modal/feature/Withdrawal/WithdrawalDetail'
+import { useState } from 'react'
+
+export default function TestWithdrawalDetailPage() {
+  const [open, setOpen] = useState(false)
+
+  // 더미 데이터
+  const dummyWithdrawal: WithdrawalDetail = {
+    id: 'u-001',
+    avatarUrl: 'https://placehold.co/80x80?text=👤',
+    name: '박사용',
+    nickname: 'user002',
+    role: '일반회원',
+    gender: '여성',
+    status: '탈퇴요청',
+    email: 'user2@example.com',
+    joinedAt: '2023-04-18T20:45:00+09:00',
+    withdrawalRequestId: 'W001',
+    requestedAt: '2024-01-16T01:30:00+09:00',
+    scheduledDeletionAt: '2024-02-16T01:30:00+09:00',
+    reason: '서비스 불만족',
+    reasonDetail: '기능이 부족하고 사용하기 불편함',
+  }
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <Button
+        btnStyle="primary"
+        btnText="회원 탈퇴 상세 모달 열기"
+        onClick={() => setOpen(true)}
+      />
+
+      <WithdrawalModal
+        open={open}
+        onClose={() => setOpen(false)}
+        data={dummyWithdrawal}
+      />
+    </div>
+  )
+}

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -8,6 +8,7 @@ export type ModalSize =
   | '2xl'
   | '3xl'
   | 'full'
+  | 'none'
 export type ModalPlacement = 'center' | 'top'
 
 export interface ModalProps {


### PR DESCRIPTION
# 🔚 Withdrawal 모듈 개발 완료

## 📌 개요
관리자 > 회원 > **탈퇴(Withdrawal)** 상세 모달을 최종 구현 및 컴포넌트 분리/리팩터링을 완료했습니다.  
로딩/에러/데이터 없음 상태를 표준화하고, 접근성 및 유지보수성을 강화했습니다.

---

## ✅ 변경 사항
- [x] `WithdrawalModal` 경량화 및 책임 분리 (핸들러/액션 유지, UI는 하위로 위임)
- [x] 섹션 분리: `WithdrawalUserView`(회원 정보), `WithdrawalInfoView`(탈퇴 정보)
- [x] 상위 조립 컴포넌트 추가: `WithdrawalDetailView` (loading / error / empty 상태 일원화)
- [x] 로딩 상태에 `Skeleton` 적용 (다크 모드/모션 감소 대응)
- [x] `useFormHandlers` 연동: `resetForm` 동기화, `handleRestore` 바인딩
- [x] 접근성 보강: `aria-busy`, 버튼 `aria-disabled` 적용
- [x] 날짜 포맷 유틸 적용: `formatDateTime(form.joinedAt | requestedAt | scheduledDeletionAt)`
- [x] 필드 렌더 방식 통일: 읽기 전용 `Field` 컴포넌트 일관 적용
- [x] 스타일 정리: 구분선/섹션 타이틀/그리드 레이아웃 일관성 확보

**주요 파일**
- `src/components/admin/member/withdrawal/WithdrawalModal.tsx`
- `src/components/admin/member/withdrawal/WithdrawalDetailView.tsx`
- `src/components/admin/member/withdrawal/WithdrawalUserView.tsx`
- `src/components/admin/member/withdrawal/WithdrawalInfoView.tsx`
- `src/components/admin/member/withdrawal/Withdrawal.types.ts`
- `src/components/ui/Skeleton.tsx`

---

## 🔗 관련 이슈
- closes **#79**

---

## 📷 참고 자료
- (추가 예정) 로딩/완료 상태 스크린샷
- 스토리북/테스트 페이지 캡처
<img width="742" height="821" alt="image" src="https://github.com/user-attachments/assets/7ac40be6-84e4-45b3-87b6-a4915fb232ee" />

---

## 💬 기타
- **검증 포인트**
  - API 지연(1~2s) 시 스켈레톤 → 실제 UI 자연 전환(레이아웃 시프트 없음)
  - 다크 모드/`prefers-reduced-motion` 환경에서 시각 경험 일관성
  - `onRequestRestore` 콜백 정상 동작(버튼 비활성/활성 및 로딩 표시)
  - 데이터 없음/에러 메시지 노출 시 가독성/접근성 확인

---
