### PR TITLE
[Feat] StudyGroup 관련 모달 컴포넌트 구현 및 리팩토링

### DIFF
--- a/src/components/ui/Modal/feature/Study/CourseCard.tsx
+++ b/src/components/ui/Modal/feature/Study/CourseCard.tsx
@@ -1,0 +1,38 @@
+import { ExternalLink } from 'lucide-react'
+import type { Course } from './Study.types'
+
+type CourseProps = {
+  course: Course
+}
+
+export default function CourseCard({ course }: CourseProps) {
+  return (
+    <article
+      className="flex items-center gap-3 rounded-xl border border-gray-200 bg-gray-50 p-3"
+      aria-label={`강의: ${course.title}`}
+    >
+      <img
+        src={course.thumbnailUrl ?? 'https://placehold.co/96x54?text=🎓'}
+        alt=""
+        className="h-14 w-22 rounded-md object-cover"
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <h5 className="truncate text-sm font-medium">{course.title}</h5>
+        {course.teacher && (
+          <div className="text-xs text-gray-500">강사: {course.teacher}</div>
+        )}
+        {course.externalUrl && (
+          <a
+            href={course.externalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-600 mt-1 inline-flex items-center gap-1 text-xs font-medium hover:underline"
+          >
+            <ExternalLink className="size-3" aria-hidden="true" /> 강의 바로가기
+          </a>
+        )}
+      </div>
+    </article>
+  )
+}

--- a/src/components/ui/Modal/feature/Study/MemberList.tsx
+++ b/src/components/ui/Modal/feature/Study/MemberList.tsx
@@ -1,0 +1,53 @@
+import { User } from 'lucide-react'
+import type { Member } from './Study.types'
+import Badge from '@/components/ui/Badge/Badge'
+
+type MemberListProps = {
+  members: Member[]
+  maxHeightClass?: string // 예: "max-h-80"
+}
+
+export default function MemberList({
+  members,
+  maxHeightClass = 'max-h-80',
+}: MemberListProps) {
+  return (
+    <div className="space-y-2">
+      {/* 큰 카드 컨테이너 */}
+      <section
+        aria-label="스터디 멤버 목록"
+        className={`rounded-2xl border border-gray-200 bg-gray-50 p-3 ${maxHeightClass} overflow-auto`}
+      >
+        <ul role="list" className="space-y-2">
+          {members.map((m) => (
+            <li key={m.id}>
+              {/* 개별 멤버 카드 */}
+              <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-100 bg-white px-4 py-3 shadow-sm hover:bg-gray-50">
+                <div className="flex min-w-0 items-center gap-2">
+                  <User className="size-6 text-gray-400" aria-hidden="true" />
+                  <span className="truncate text-sm text-gray-800">
+                    {m.name}
+                  </span>
+                </div>
+
+                {m.isLeader && (
+                  <Badge tone="yellow" size="sm" className="shrink-0">
+                    리더
+                  </Badge>
+                )}
+              </div>
+            </li>
+          ))}
+
+          {members.length === 0 && (
+            <li>
+              <div className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-8 text-center text-sm text-gray-500">
+                등록된 멤버가 없습니다.
+              </div>
+            </li>
+          )}
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/components/ui/Modal/feature/Study/Study.types.ts
+++ b/src/components/ui/Modal/feature/Study/Study.types.ts
@@ -1,4 +1,4 @@
-export type StudyStatus = '대기중' | '진행중' | '종료'
+export type StudyStatus = '대기중' | '진행중' | '종료됨'
 
 export type Member = {
   id: string

--- a/src/components/ui/Modal/feature/Study/Study.types.ts
+++ b/src/components/ui/Modal/feature/Study/Study.types.ts
@@ -1,0 +1,31 @@
+export type StudyStatus = '대기중' | '진행중' | '종료'
+
+export type Member = {
+  id: string
+  name: string
+  isLeader?: boolean
+}
+
+export type Course = {
+  id: string
+  title: string
+  teacher?: string
+  thumbnailUrl?: string
+  externalUrl?: string
+}
+
+export type StudyGroupDetail = {
+  id: number
+  uuid: string
+  name: string
+  currentMembers: number
+  capacity: number
+  startDate: string // ISO
+  endDate: string // ISO
+  status: StudyStatus
+  createdAt: string // ISO
+  updatedAt: string // ISO
+  coverImageUrl?: string
+  members: Member[]
+  courses: Course[]
+}

--- a/src/components/ui/Modal/feature/Study/StudyGroupDetailLeft.tsx
+++ b/src/components/ui/Modal/feature/Study/StudyGroupDetailLeft.tsx
@@ -1,0 +1,113 @@
+import Badge from '@/components/ui/Badge/Badge'
+import type { StudyGroupDetail } from './Study.types'
+import { studyToTone } from '@/lib'
+
+type Props = {
+  data?: StudyGroupDetail
+  loading?: boolean
+  errorText?: string | null
+}
+
+const fmt = (iso?: string): string =>
+  iso ? new Date(iso).toLocaleDateString() : '-'
+
+export default function StudyGroupDetailLeft({
+  data,
+  loading,
+  errorText,
+}: Props) {
+  if (loading) {
+    return (
+      <div className="space-y-5">
+        <div className="aspect-[16/9] w-full animate-pulse rounded-2xl bg-gray-200" />
+        <div className="grid grid-cols-2 gap-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="h-6 animate-pulse rounded bg-gray-200" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (errorText) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+        {errorText}
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div className="text-sm text-gray-500">표시할 데이터가 없습니다.</div>
+    )
+  }
+
+  return (
+    <section className="space-y-5" aria-label="스터디 기본 정보">
+      <div>
+        <div className="mb-2 text-xs text-gray-500">
+          스터디 그룹 대표 이미지
+        </div>
+        <img
+          src={
+            data.coverImageUrl ??
+            'https://placehold.co/960x540?text=Study+Group'
+          }
+          alt="스터디 그룹 대표 이미지"
+          className="aspect-[16/9] w-full rounded-2xl object-cover"
+        />
+      </div>
+      <div className="sm:col-span-2">
+        <div className="text-xs text-gray-500">그룹명</div>
+        <div className="text-base font-semibold">{data.name}</div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <div>
+          <div className="text-xs text-gray-500">고유 ID</div>
+          <div className="text-sm">{data.id}</div>
+        </div>
+        <div>
+          <div className="text-xs text-gray-500">UUID</div>
+          <div className="font-mono text-sm">{data.uuid}</div>
+        </div>
+
+        <div>
+          <div className="text-xs text-gray-500">인원 현황</div>
+          <div className="text-sm">
+            <span className="text-primary-600">{data.currentMembers}</span>
+            <span> / {data.capacity}명</span>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs text-gray-500">스터디 상태</div>
+          <Badge tone={studyToTone[data.status]}>{data.status}</Badge>
+        </div>
+
+        <div>
+          <div className="text-xs text-gray-500">스터디 시작일</div>
+          <div className="text-sm">{fmt(data.startDate)}</div>
+        </div>
+        <div>
+          <div className="text-xs text-gray-500">스터디 종료일</div>
+          <div className="text-sm">{fmt(data.endDate)}</div>
+        </div>
+
+        <div>
+          <div className="text-xs text-gray-500">생성일시</div>
+          <div className="text-sm">
+            {data.createdAt ? new Date(data.createdAt).toLocaleString() : '-'}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-gray-500">수정일시</div>
+          <div className="text-sm">
+            {data.updatedAt ? new Date(data.updatedAt).toLocaleString() : '-'}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/ui/Modal/feature/Study/StudyGroupDetailLeft.tsx
+++ b/src/components/ui/Modal/feature/Study/StudyGroupDetailLeft.tsx
@@ -2,10 +2,8 @@ import Badge from '@/components/ui/Badge/Badge'
 import type { StudyGroupDetail } from './Study.types'
 import { studyToTone } from '@/lib'
 
-type Props = {
+type StudyGroupDetailLeftProps = {
   data?: StudyGroupDetail
-  loading?: boolean
-  errorText?: string | null
 }
 
 const fmt = (iso?: string): string =>
@@ -13,101 +11,88 @@ const fmt = (iso?: string): string =>
 
 export default function StudyGroupDetailLeft({
   data,
-  loading,
-  errorText,
-}: Props) {
-  if (loading) {
-    return (
-      <div className="space-y-5">
-        <div className="aspect-[16/9] w-full animate-pulse rounded-2xl bg-gray-200" />
-        <div className="grid grid-cols-2 gap-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="h-6 animate-pulse rounded bg-gray-200" />
-          ))}
-        </div>
-      </div>
-    )
-  }
-
-  if (errorText) {
-    return (
-      <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-        {errorText}
-      </div>
-    )
-  }
-
+}: StudyGroupDetailLeftProps) {
   if (!data) {
     return (
-      <div className="text-sm text-gray-500">표시할 데이터가 없습니다.</div>
+      <div className="body-sm text-gray-500">표시할 데이터가 없습니다.</div>
     )
   }
 
   return (
-    <section className="space-y-5" aria-label="스터디 기본 정보">
-      <div>
-        <div className="mb-2 text-xs text-gray-500">
-          스터디 그룹 대표 이미지
-        </div>
-        <img
-          src={
-            data.coverImageUrl ??
-            'https://placehold.co/960x540?text=Study+Group'
-          }
-          alt="스터디 그룹 대표 이미지"
-          className="aspect-[16/9] w-full rounded-2xl object-cover"
-        />
-      </div>
+    <section
+      aria-labelledby="study-group-title"
+      className="space-y-5"
+      aria-label="스터디 기본 정보"
+    >
+      <header>
+        <figure>
+          <img
+            src={
+              data.coverImageUrl ??
+              'https://placehold.co/960x540?text=Study+Group'
+            }
+            alt="스터디 그룹 대표 이미지"
+            className="aspect-[16/9] w-full rounded-2xl object-cover"
+          />
+          <figcaption className="sr-only">대표 이미지</figcaption>
+        </figure>
+      </header>
+
       <div className="sm:col-span-2">
-        <div className="text-xs text-gray-500">그룹명</div>
+        <div className="body-xs text-gray-500">그룹명</div>
         <div className="text-base font-semibold">{data.name}</div>
       </div>
 
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div>
-          <div className="text-xs text-gray-500">고유 ID</div>
-          <div className="text-sm">{data.id}</div>
-        </div>
-        <div>
-          <div className="text-xs text-gray-500">UUID</div>
-          <div className="font-mono text-sm">{data.uuid}</div>
+          <dt className="body-xs text-gray-500">고유 ID</dt>
+          <dd className="body-sm">{data.id}</dd>
         </div>
 
         <div>
-          <div className="text-xs text-gray-500">인원 현황</div>
-          <div className="text-sm">
+          <dt className="body-xs text-gray-500">UUID</dt>
+          <dd className="body-sm font-mono">{data.uuid}</dd>
+        </div>
+
+        <div>
+          <dt className="body-xs text-gray-500">인원 현황</dt>
+          <dd className="body-sm">
             <span className="text-primary-600">{data.currentMembers}</span>
             <span> / {data.capacity}명</span>
-          </div>
+          </dd>
         </div>
 
         <div>
-          <div className="text-xs text-gray-500">스터디 상태</div>
-          <Badge tone={studyToTone[data.status]}>{data.status}</Badge>
+          <dt className="body-xs text-gray-500">스터디 상태</dt>
+          <dd>
+            <Badge tone={studyToTone[data.status]}>{data.status}</Badge>
+          </dd>
         </div>
 
         <div>
-          <div className="text-xs text-gray-500">스터디 시작일</div>
-          <div className="text-sm">{fmt(data.startDate)}</div>
-        </div>
-        <div>
-          <div className="text-xs text-gray-500">스터디 종료일</div>
-          <div className="text-sm">{fmt(data.endDate)}</div>
+          <dt className="body-xs text-gray-500">스터디 시작일</dt>
+          <dd className="body-sm">{fmt(data.startDate)}</dd>
         </div>
 
         <div>
-          <div className="text-xs text-gray-500">생성일시</div>
-          <div className="text-sm">
+          <dt className="body-xs text-gray-500">스터디 종료일</dt>
+          <dd className="body-sm">{fmt(data.endDate)}</dd>
+        </div>
+
+        <div>
+          <dt className="body-xs text-gray-500">생성일시</dt>
+          <dd className="body-sm">
             {data.createdAt ? new Date(data.createdAt).toLocaleString() : '-'}
-          </div>
+          </dd>
         </div>
+
         <div>
-          <div className="text-xs text-gray-500">수정일시</div>
-          <div className="text-sm">
+          <dt className="body-xs text-gray-500">수정일시</dt>
+          <dd className="body-sm">
             {data.updatedAt ? new Date(data.updatedAt).toLocaleString() : '-'}
-          </div>
+          </dd>
         </div>
-      </div>
+      </dl>
     </section>
   )
 }

--- a/src/components/ui/Modal/feature/Study/StudyGroupDetailModal.tsx
+++ b/src/components/ui/Modal/feature/Study/StudyGroupDetailModal.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@/components/ui/Button'
+import Modal from '../../Modal'
+import type { StudyGroupDetail } from './Study.types'
+import StudyGroupDetailLeft from './StudyGroupDetailLeft'
+import StudyGroupDetailRight from './StudyGroupDetailRight'
+
+type StudyGroupDetailModalProps = {
+  open: boolean
+  onClose: () => void
+  data?: StudyGroupDetail
+  loading?: boolean
+  errorText?: string | null
+  columnsClassName?: string
+}
+
+export default function StudyGroupDetailModal({
+  open,
+  onClose,
+  data,
+  loading,
+  errorText,
+  columnsClassName = `md:grid-cols-[1fr_1fr]`,
+}: StudyGroupDetailModalProps) {
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="스터디 그룹 상세 정보"
+      size="none"
+      className="w-[1024px]"
+    >
+      <Modal.Header>
+        <Modal.Title id="StudyGroup-title">스터디 그룹 상세 정보</Modal.Title>
+      </Modal.Header>
+      <div className="border-b border-gray-200" />
+
+      <Modal.Body className={`grid gap-6 ${columnsClassName} max-h-[65vh] p-6`}>
+        <StudyGroupDetailLeft
+          data={data}
+          loading={loading}
+          errorText={errorText}
+        />
+        <StudyGroupDetailRight
+          members={data?.members}
+          courses={data?.courses}
+          loading={loading}
+        />
+      </Modal.Body>
+      <div className="border-b border-gray-200" />
+      {/* Footer */}
+      <Modal.Footer align="end" className="bg-gray-50">
+        <Button btnStyle="cancel" btnText="닫기" onClick={onClose} />
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/src/components/ui/Modal/feature/Study/StudyGroupDetailModal.tsx
+++ b/src/components/ui/Modal/feature/Study/StudyGroupDetailModal.tsx
@@ -3,6 +3,7 @@ import Modal from '../../Modal'
 import type { StudyGroupDetail } from './Study.types'
 import StudyGroupDetailLeft from './StudyGroupDetailLeft'
 import StudyGroupDetailRight from './StudyGroupDetailRight'
+import ModalSkeleton from '@/components/ui/Skeleton/ModalSkeleton'
 
 type StudyGroupDetailModalProps = {
   open: boolean
@@ -34,17 +35,22 @@ export default function StudyGroupDetailModal({
       </Modal.Header>
       <div className="border-b border-gray-200" />
 
-      <Modal.Body className={`grid gap-6 ${columnsClassName} max-h-[65vh] p-6`}>
-        <StudyGroupDetailLeft
-          data={data}
-          loading={loading}
-          errorText={errorText}
-        />
-        <StudyGroupDetailRight
-          members={data?.members}
-          courses={data?.courses}
-          loading={loading}
-        />
+      <Modal.Body className={`max-h-[65vh] p-6`}>
+        {loading ? (
+          <ModalSkeleton rows={8} />
+        ) : errorText ? (
+          <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {errorText}
+          </div>
+        ) : (
+          <div className={`grid gap-6 ${columnsClassName}`}>
+            <StudyGroupDetailLeft data={data} />
+            <StudyGroupDetailRight
+              members={data?.members}
+              courses={data?.courses}
+            />
+          </div>
+        )}
       </Modal.Body>
       <div className="border-b border-gray-200" />
       {/* Footer */}

--- a/src/components/ui/Modal/feature/Study/StudyGroupDetailRight.tsx
+++ b/src/components/ui/Modal/feature/Study/StudyGroupDetailRight.tsx
@@ -2,28 +2,15 @@ import CourseCard from './CourseCard'
 import MemberList from './MemberList'
 import type { Course, Member } from './Study.types'
 
-type Props = {
+type StudyGroupDetailRightProps = {
   members?: Member[]
   courses?: Course[]
-  loading?: boolean
 }
 
 export default function StudyGroupDetailRight({
   members,
   courses,
-  loading,
-}: Props) {
-  if (loading) {
-    return (
-      <aside className="space-y-5">
-        <div className="h-6 w-28 animate-pulse rounded bg-gray-200" />
-        <div className="h-64 animate-pulse rounded-xl bg-gray-200" />
-        <div className="h-6 w-28 animate-pulse rounded bg-gray-200" />
-        <div className="h-24 animate-pulse rounded-xl bg-gray-200" />
-      </aside>
-    )
-  }
-
+}: StudyGroupDetailRightProps) {
   return (
     <aside className="space-y-5">
       <div className="space-y-2">

--- a/src/components/ui/Modal/feature/Study/StudyGroupDetailRight.tsx
+++ b/src/components/ui/Modal/feature/Study/StudyGroupDetailRight.tsx
@@ -1,0 +1,50 @@
+import CourseCard from './CourseCard'
+import MemberList from './MemberList'
+import type { Course, Member } from './Study.types'
+
+type Props = {
+  members?: Member[]
+  courses?: Course[]
+  loading?: boolean
+}
+
+export default function StudyGroupDetailRight({
+  members,
+  courses,
+  loading,
+}: Props) {
+  if (loading) {
+    return (
+      <aside className="space-y-5">
+        <div className="h-6 w-28 animate-pulse rounded bg-gray-200" />
+        <div className="h-64 animate-pulse rounded-xl bg-gray-200" />
+        <div className="h-6 w-28 animate-pulse rounded bg-gray-200" />
+        <div className="h-24 animate-pulse rounded-xl bg-gray-200" />
+      </aside>
+    )
+  }
+
+  return (
+    <aside className="space-y-5">
+      <div className="space-y-2">
+        <div className="text-xs text-gray-500">멤버 목록</div>
+        <MemberList members={members ?? []} maxHeightClass="max-h-80" />
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-xs text-gray-500">스터디 강의 목록</div>
+        {courses && courses.length > 0 ? (
+          <div className="space-y-3">
+            {courses.map((c) => (
+              <CourseCard key={c.id} course={c} />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-xl border border-gray-200 p-4 text-sm text-gray-500">
+            연관 강의가 없습니다.
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/src/components/ui/Modal/feature/Withdrawal/WithdrawalUserView.tsx
+++ b/src/components/ui/Modal/feature/Withdrawal/WithdrawalUserView.tsx
@@ -12,7 +12,7 @@ function WithdrawalUserViewBase({ form }: Props) {
   return (
     <>
       {/* Header */}
-      <Modal.Header className="pb-0">
+      <Modal.Header className="pb-2">
         <Modal.Title>회원 정보</Modal.Title>
       </Modal.Header>
 

--- a/src/components/ui/Modal/parts/Title.tsx
+++ b/src/components/ui/Modal/parts/Title.tsx
@@ -6,7 +6,7 @@ export default function Title({
   id?: string
 }) {
   return (
-    <h4 id={id} className="mb-2 font-bold">
+    <h4 id={id} className="mb-0 font-bold">
       {children}
     </h4>
   )

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -1,4 +1,4 @@
-import type { UserRow } from '@/components/table/Table.types'
+import type { StudyGroupRow, UserRow } from '@/components/table/Table.types'
 
 export type Tone = 'purple' | 'blue' | 'green' | 'red' | 'yellow' | 'gray'
 export type Variant =
@@ -31,4 +31,10 @@ export const statusToTone: Record<UserRow['status'], Tone> = {
   정지: 'red',
   탈퇴요청: 'yellow',
   비활성: 'gray',
+}
+
+export const studyToTone: Record<StudyGroupRow['status'], Tone> = {
+  대기중: 'blue',
+  진행중: 'green',
+  종료됨: 'gray',
 }

--- a/src/test-pages/StudyModalTest.tsx
+++ b/src/test-pages/StudyModalTest.tsx
@@ -23,6 +23,11 @@ export default function TestStudyModalPage() {
       { id: 'm2', name: 'APIDeveloper' },
       { id: 'm3', name: 'BackEndDev' },
       { id: 'm4', name: 'DBMaster' },
+      { id: 'm5', name: '병원간 서연님' },
+      { id: 'm6', name: '예비군간 민제님' },
+      { id: 'm7', name: '집가고픈 명우님' },
+      { id: 'm8', name: '필터정렬지옥 민창님' },
+      { id: 'm9', name: '면접생각에 신난 여진님' },
     ],
     courses: [
       {

--- a/src/test-pages/StudyModalTest.tsx
+++ b/src/test-pages/StudyModalTest.tsx
@@ -1,0 +1,54 @@
+import { Button } from '@/components/ui/Button'
+import type { StudyGroupDetail } from '@/components/ui/Modal/feature/Study/Study.types'
+import StudyGroupDetailModal from '@/components/ui/Modal/feature/Study/StudyGroupDetailModal'
+import { useState } from 'react'
+
+export default function TestStudyModalPage() {
+  const [open, setOpen] = useState(true)
+  const mockDetail: StudyGroupDetail = {
+    id: 2,
+    uuid: 'group-uuid-002',
+    name: 'Spring Boot 실무 스터디',
+    currentMembers: 6,
+    capacity: 10,
+    startDate: '2024-03-15T00:00:00Z',
+    endDate: '2024-06-15T00:00:00Z',
+    status: '대기중',
+    createdAt: '2024-01-25T14:20:00Z',
+    updatedAt: '2024-02-02T09:30:00Z',
+    coverImageUrl:
+      'https://images.unsplash.com/photo-1557800636-894a64c1696f?q=80&w=1200&auto=format&fit=crop',
+    members: [
+      { id: 'm1', name: 'SpringMaster', isLeader: true },
+      { id: 'm2', name: 'APIDeveloper' },
+      { id: 'm3', name: 'BackEndDev' },
+      { id: 'm4', name: 'DBMaster' },
+    ],
+    courses: [
+      {
+        id: 'c1',
+        title: 'Spring Boot와 JPA 실무 완전 정복',
+        teacher: '이정한',
+        thumbnailUrl: 'https://placehold.co/160x90?text=JPA',
+        externalUrl: 'https://example.com/course/1',
+      },
+    ],
+  }
+
+  return (
+    <>
+      <div className="flex h-screen items-center justify-center">
+        <Button
+          btnText="모달 열기"
+          btnStyle="primary"
+          onClick={() => setOpen(true)}
+        />
+      </div>
+      <StudyGroupDetailModal
+        open={open}
+        onClose={() => setOpen(false)}
+        data={mockDetail}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## 📌 개요

StudyGroup 관련 모달 작성 및 리팩토링 작업을 진행

## ✅ 변경 사항

- [ ] StudyGroup 생성 모달 구현
- [ ] StudyGroup 상세 모달 UI 및 상태 연동
- [ ] Skeleton / Badge 컴포넌트 활용하여 UI 일관성 강화

## 🔗 관련 이슈

#93

## 📷 참고 자료 
<img width="1140" height="848" alt="image" src="https://github.com/user-attachments/assets/95fae8dd-97eb-4a27-92d4-394af77b71f4" />


## 💬 기타

- 기존 중복 로직을 최대한 공용 훅과 컴포넌트로 정리했습니다.  
- 추가 확인이 필요한 부분은 리뷰 코멘트 부탁

---

closes #93
